### PR TITLE
Timers in diffusion examples

### DIFF
--- a/diffusion/heat_1D.chpl
+++ b/diffusion/heat_1D.chpl
@@ -8,6 +8,11 @@
   the command line (e.g., `./heat_1D --nt=100`)
 */
 
+import Time.Timer;
+
+// create a stopwatch to time kernel execution
+var t = new Timer();
+
 // declare configurable constants with default values
 config const nx = 4096,     // number of grid points in x
              nt = 50,       // number of time steps
@@ -28,6 +33,7 @@ u[nx/4..nx/2] = 2.0;
 var un = u;
 
 // iterate for 'nt' time steps
+t.start();
 for 1..nt {
   // swap the arrays to prepare for the next time step
   u <=> un;
@@ -40,4 +46,6 @@ for 1..nt {
 // print final results
 const mean = (+ reduce u) / u.size,
       stdDev = sqrt((+ reduce (u - mean)**2) / u.size);
+t.stop();
 writeln("mean: ", mean, " stdDev: ", stdDev);
+writeln("time: ", t.elapsed(), " (sec)");

--- a/diffusion/heat_1D_dist.chpl
+++ b/diffusion/heat_1D_dist.chpl
@@ -11,7 +11,11 @@
   the command line (e.g., `./heat_1D --nt=100`)
 */
 
-use BlockDist;
+import BlockDist.Block,
+      Time.Timer;
+
+// create a stopwatch to time kernel execution
+var t = new Timer();
 
 // declare configurable constants with default values
 config const nx = 4096,     // number of grid points in x
@@ -33,6 +37,7 @@ u[nx/4..nx/2] = 2;
 var un = u;
 
 // iterate for 'nt' time steps
+t.start();
 for 1..nt {
   // swap arrays to prepare for next time step
   u <=> un;
@@ -45,4 +50,6 @@ for 1..nt {
 // print final results
 const mean = (+ reduce u) / u.size,
       stdDev = sqrt((+ reduce (u - mean)**2) / u.size);
+t.stop();
 writeln("mean: ", mean, " stdDev: ", stdDev);
+writeln("time: ", t.elapsed(), " (sec)");

--- a/diffusion/heat_1D_tasks.chpl
+++ b/diffusion/heat_1D_tasks.chpl
@@ -10,6 +10,11 @@
   the command line (e.g., `./heat_1D --nt=100`)
 */
 
+import Time.Timer;
+
+// create a stopwatch to time kernel execution
+var t = new Timer();
+
 // declare configurable constants with default values
 config const nx = 4096,     // number of grid points in x
              nt = 50,       // number of time steps
@@ -35,12 +40,15 @@ var halos : [0..1, 0..<nTasks] sync real;
 param LEFT = 0, RIGHT = 1;
 
 // run the simulation across tasks
+t.start();
 coforall tid in 0..<nTasks do work(tid);
 
 // print final results
 const mean = (+ reduce u) / u.size,
       stdDev = sqrt((+ reduce (u - mean)**2) / u.size);
+t.stop();
 writeln("mean: ", mean, " stdDev: ", stdDev);
+writeln("time: ", t.elapsed(), " (sec)");
 
 proc work(tid: int) {
   // define region of the global array owned by this task

--- a/diffusion/heat_2D.chpl
+++ b/diffusion/heat_2D.chpl
@@ -8,6 +8,11 @@
   the command line (e.g., `./heat_2D --nt=100`)
 */
 
+import Time.Timer;
+
+// create a stopwatch to time kernel execution
+var t = new Timer();
+
 // declare configurable constants with default values
 config const nx = 4096,     // number of grid points in x
              ny = 4096,     // number of grid points in y
@@ -29,6 +34,7 @@ u[nx/4..nx/2, ny/4..ny/2] = 2.0;
 var un = u;
 
 // iterate for 'nt' time steps
+t.start();
 for 1..nt {
   // swap arrays to prepare for next time step
   u <=> un;
@@ -42,4 +48,6 @@ for 1..nt {
 // print final results
 const mean = (+ reduce u) / u.size,
       stdDev = sqrt((+ reduce (u - mean)**2) / u.size);
+t.stop();
 writeln("mean: ", mean, " stdDev: ", stdDev);
+writeln("time: ", t.elapsed(), " (sec)");

--- a/diffusion/heat_2D_dist.chpl
+++ b/diffusion/heat_2D_dist.chpl
@@ -10,7 +10,11 @@
   the command line (e.g., `./heat_2D_dist --nt=100`)
 */
 
-import BlockDist.Block;
+import BlockDist.Block,
+       Time.Timer;
+
+// create a stopwatch to time kernel execution
+var t = new Timer();
 
 // declare configurable constants with default values
 config const nx = 4096,     // number of grid points in x
@@ -35,6 +39,7 @@ u[nx/4..nx/2, ny/4..ny/2] = 2.0;
 var un = u;
 
 // iterate for 'nt' time steps
+t.start();
 for 1..nt {
   // swap arrays to prepare for next time step
   u <=> un;
@@ -48,4 +53,6 @@ for 1..nt {
 // print final results
 const mean = (+ reduce u) / u.size,
       stdDev = sqrt((+ reduce (u - mean)**2) / u.size);
+t.stop();
 writeln("mean: ", mean, " stdDev: ", stdDev);
+writeln("time: ", t.elapsed(), " (sec)");

--- a/diffusion/heat_2D_dist_buffers.chpl
+++ b/diffusion/heat_2D_dist_buffers.chpl
@@ -12,7 +12,11 @@
 */
 
 import BlockDist.Block,
-       Collectives.barrier;
+       Collectives.barrier,
+       Time.Timer;
+
+// create a stopwatch to time kernel execution
+var t = new Timer();
 
 // compile with `-sRunCommDiag=true` to see comm diagnostics
 use CommDiagnostics;
@@ -62,6 +66,7 @@ proc main() {
   if RunCommDiag then startCommDiagnostics();
 
   // spawn one task for each locale
+  t.start();
   coforall (loc, (tidX, tidY)) in zip(u.targetLocales(), LOCALE_DOM) {
     // run initialization and computation on the task for this locale
     on loc {
@@ -87,7 +92,9 @@ proc main() {
   // print final results
   const mean = (+ reduce u) / u.size,
         stdDev = sqrt((+ reduce (u - mean)**2) / u.size);
+  t.stop();
   writeln("mean: ", mean, " stdDev: ", stdDev);
+  writeln("time: ", t.elapsed(), " (sec)");
 }
 
 proc work(tidX: int, tidY: int) {

--- a/diffusion/heat_2D_dist_exchanges_abstracted.chpl
+++ b/diffusion/heat_2D_dist_exchanges_abstracted.chpl
@@ -15,7 +15,11 @@
 */
 
 import BlockDist.Block,
-       Collectives.barrier;
+       Collectives.barrier,
+       Time.Timer;
+
+// create a stopwatch to time kernel execution
+var t = new Timer();
 
 // compile with `-sRunCommDiag=true` to see comm diagnostics
 use CommDiagnostics;
@@ -120,6 +124,7 @@ proc main() {
   if RunCommDiag then startCommDiagnostics();
 
   // spawn one task for each locale
+  t.start();
   coforall (loc, (tidX, tidY)) in zip(u.targetLocales(), LOCALE_DOM) {
     // run initialization and computation on the task for this locale
     on loc {
@@ -146,7 +151,9 @@ proc main() {
   // print final results
   const mean = (+ reduce u) / u.size,
         stdDev = sqrt((+ reduce (u - mean)**2) / u.size);
+  t.stop();
   writeln("mean: ", mean, " stdDev: ", stdDev);
+  writeln("time: ", t.elapsed(), " (sec)");
 }
 
 proc work(tidX: int, tidY: int) {

--- a/diffusion/heat_2D_dist_stencil.chpl
+++ b/diffusion/heat_2D_dist_stencil.chpl
@@ -11,7 +11,11 @@
   the command line (e.g., `./heat_2D_dist --nt=100`)
 */
 
-use StencilDist;
+import StencilDist.Stencil,
+       Time.Timer;
+
+// create a stopwatch to time kernel execution
+var t = new Timer();
 
 // declare configurable constants with default values
 config const nx = 4096,     // number of grid points in x
@@ -36,6 +40,7 @@ u[nx/4..nx/2, ny/4..ny/2] = 2.0;
 var un = u;
 
 // iterate for 'nt' time steps
+t.start();
 for 1..nt {
   // swap arrays to prepare for next time step
   u <=> un;
@@ -52,4 +57,6 @@ for 1..nt {
 // print final results
 const mean = (+ reduce u) / u.size,
       stdDev = sqrt((+ reduce (u - mean)**2) / u.size);
+t.stop();
 writeln("mean: ", mean, " stdDev: ", stdDev);
+writeln("time: ", t.elapsed(), " (sec)");


### PR DESCRIPTION
Add Timers to diffusion examples to print out kernel time in seconds. Mean and standard-deviation computations are included in timing to match UPC++ examples.